### PR TITLE
Add thumbnails under media:group as well (YouTube format)

### DIFF
--- a/lib/domain/media/group.dart
+++ b/lib/domain/media/group.dart
@@ -2,21 +2,23 @@ import 'package:dart_rss/domain/media/category.dart';
 import 'package:dart_rss/domain/media/content.dart';
 import 'package:dart_rss/domain/media/credit.dart';
 import 'package:dart_rss/domain/media/rating.dart';
+import 'package:dart_rss/domain/media/thumbnail.dart';
 import 'package:dart_rss/util/helpers.dart';
 import 'package:xml/xml.dart';
 
 class Group {
   final List<Content> contents;
   final List<Credit> credits;
+  final List<Thumbnail> thumbnails;
   final Category category;
   final Rating rating;
 
-  Group({
-    this.contents,
-    this.credits,
-    this.category,
-    this.rating,
-  });
+  Group(
+      {this.contents,
+      this.credits,
+      this.thumbnails,
+      this.category,
+      this.rating});
 
   factory Group.parse(XmlElement element) {
     if (element == null) {
@@ -28,6 +30,9 @@ class Group {
       }).toList(),
       credits: element.findElements("media:credit").map((e) {
         return new Credit.parse(e);
+      }).toList(),
+      thumbnails: element.findElements("media:thumbnail").map((e) {
+        return new Thumbnail.parse(e);
       }).toList(),
       category: new Category.parse(
         findElementOrNull(element, "media:category"),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
   sdk: ">=2.6.0 <3.0.0"
 dependencies:
   xml: ^3.0.0
-  http: ^0.11.0
+  http: ^0.12.0+2
   meta: ^1.0.0
   intl: ^0.16.0
 

--- a/test/atom_test.dart
+++ b/test/atom_test.dart
@@ -88,7 +88,7 @@ void main() {
     expect(item.content, "This is content 1");
     expect(item.rights, "This is rights 1");
   });
-  test("parse Atom-Media.xml", (){
+  test("parse Atom-Media.xml", () {
     var xmlString = new File("test/xml/Atom-Media.xml").readAsStringSync();
 
     var feed = new AtomFeed.parse(xmlString);
@@ -97,12 +97,18 @@ void main() {
     expect(feed.updated, "2018-04-06T13:02:46Z");
 
     expect(feed.items.length, 1);
-    
+
     var item = feed.items.first;
     expect(item.media.group.contents.length, 5);
     expect(item.media.group.credits.length, 2);
     expect(item.media.group.category.value, "music/artist name/album/song");
     expect(item.media.group.rating.value, "nonadult");
+    expect(item.media.group.thumbnails.length, 2);
+    var mediaGroupThumbnail = item.media.group.thumbnails.first;
+    expect(mediaGroupThumbnail.url, "http://www.foo.com/thumbnail_a.jpg");
+    expect(mediaGroupThumbnail.width, "75");
+    expect(mediaGroupThumbnail.height, "50");
+    expect(mediaGroupThumbnail.time, "12:05:01.123");
 
     expect(item.media.contents.length, 2);
     var mediaContent = item.media.contents.first;
@@ -123,7 +129,8 @@ void main() {
     expect(mediaCredit.scheme, "urn:yvs");
     expect(mediaCredit.value, "copyright holder of the entity");
 
-    expect(item.media.category.scheme, "http://search.yahoo.com/mrss/category_ schema");
+    expect(item.media.category.scheme,
+        "http://search.yahoo.com/mrss/category_ schema");
     expect(item.media.category.label, "Music");
     expect(item.media.category.value, "music/artist/album/song");
 
@@ -134,10 +141,11 @@ void main() {
     expect(item.media.title.value, "The Judy's -- The Moo Song");
 
     expect(item.media.description.type, "plain");
-    expect(item.media.description.value, "This was some really bizarre band I listened to as a young lad.");
-    
+    expect(item.media.description.value,
+        "This was some really bizarre band I listened to as a young lad.");
+
     expect(item.media.keywords, "kitty, cat, big dog, yarn, fluffy");
-  
+
     expect(item.media.thumbnails.length, 2);
     var mediaThumbnail = item.media.thumbnails.first;
     expect(mediaThumbnail.url, "http://www.foo.com/keyframe1.jpg");
@@ -184,7 +192,8 @@ void main() {
     expect(item.media.embed.height, 323);
     expect(item.media.embed.params.length, 5);
     expect(item.media.embed.params.first.name, "type");
-    expect(item.media.embed.params.first.value, "application/x-shockwave-flash");
+    expect(
+        item.media.embed.params.first.value, "application/x-shockwave-flash");
 
     expect(item.media.responses.length, 2);
     expect(item.media.responses.first, "http://www.response1.com");
@@ -200,7 +209,8 @@ void main() {
     expect(item.media.prices.length, 2);
     expect(item.media.prices.first.price, 19.99);
     expect(item.media.prices.first.type, "rent");
-    expect(item.media.prices.first.info, "http://www.dummy.jp/package_info.html");
+    expect(
+        item.media.prices.first.info, "http://www.dummy.jp/package_info.html");
     expect(item.media.prices.first.currency, "EUR");
 
     expect(item.media.license.type, "text/html");

--- a/test/atom_test.dart
+++ b/test/atom_test.dart
@@ -88,7 +88,7 @@ void main() {
     expect(item.content, "This is content 1");
     expect(item.rights, "This is rights 1");
   });
-  test("parse Atom-Media.xml", () {
+  test("parse Atom-Media.xml", (){
     var xmlString = new File("test/xml/Atom-Media.xml").readAsStringSync();
 
     var feed = new AtomFeed.parse(xmlString);
@@ -97,7 +97,7 @@ void main() {
     expect(feed.updated, "2018-04-06T13:02:46Z");
 
     expect(feed.items.length, 1);
-
+    
     var item = feed.items.first;
     expect(item.media.group.contents.length, 5);
     expect(item.media.group.credits.length, 2);
@@ -129,8 +129,7 @@ void main() {
     expect(mediaCredit.scheme, "urn:yvs");
     expect(mediaCredit.value, "copyright holder of the entity");
 
-    expect(item.media.category.scheme,
-        "http://search.yahoo.com/mrss/category_ schema");
+    expect(item.media.category.scheme, "http://search.yahoo.com/mrss/category_ schema");
     expect(item.media.category.label, "Music");
     expect(item.media.category.value, "music/artist/album/song");
 
@@ -141,11 +140,10 @@ void main() {
     expect(item.media.title.value, "The Judy's -- The Moo Song");
 
     expect(item.media.description.type, "plain");
-    expect(item.media.description.value,
-        "This was some really bizarre band I listened to as a young lad.");
-
+    expect(item.media.description.value, "This was some really bizarre band I listened to as a young lad.");
+    
     expect(item.media.keywords, "kitty, cat, big dog, yarn, fluffy");
-
+  
     expect(item.media.thumbnails.length, 2);
     var mediaThumbnail = item.media.thumbnails.first;
     expect(mediaThumbnail.url, "http://www.foo.com/keyframe1.jpg");
@@ -192,8 +190,7 @@ void main() {
     expect(item.media.embed.height, 323);
     expect(item.media.embed.params.length, 5);
     expect(item.media.embed.params.first.name, "type");
-    expect(
-        item.media.embed.params.first.value, "application/x-shockwave-flash");
+    expect(item.media.embed.params.first.value, "application/x-shockwave-flash");
 
     expect(item.media.responses.length, 2);
     expect(item.media.responses.first, "http://www.response1.com");
@@ -209,8 +206,7 @@ void main() {
     expect(item.media.prices.length, 2);
     expect(item.media.prices.first.price, 19.99);
     expect(item.media.prices.first.type, "rent");
-    expect(
-        item.media.prices.first.info, "http://www.dummy.jp/package_info.html");
+    expect(item.media.prices.first.info, "http://www.dummy.jp/package_info.html");
     expect(item.media.prices.first.currency, "EUR");
 
     expect(item.media.license.type, "text/html");

--- a/test/xml/Atom-Media.xml
+++ b/test/xml/Atom-Media.xml
@@ -50,6 +50,8 @@
             <media:credit role="musician">band member 2</media:credit>
             <media:category>music/artist name/album/song</media:category>
             <media:rating>nonadult</media:rating>
+            <media:thumbnail url="http://www.foo.com/thumbnail_a.jpg" width="75" height="50" time="12:05:01.123" />
+            <media:thumbnail url="http://www.foo.com/thumbnail_b.jpg" width="150" height="100" time="12:05:01.125" />
         </media:group>
         <media:title type="plain">The Judy's -- The Moo Song</media:title>
         <media:description type="plain">This was some really bizarre band I listened to as a young lad.</media:description>


### PR DESCRIPTION
Hi!

I see that some feeds return thumbnails under the media:group as well (YouTube in particular).
This PR also adds these.

Here's an example feed: https://www.youtube.com/feeds/videos.xml?user=enyay