### PR TITLE
Update outdated http and test dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,9 +6,9 @@ environment:
   sdk: ">=2.6.0 <3.0.0"
 dependencies:
   xml: ^3.0.0
-  http: ^0.11.0
+  http: ^0.11.1
   meta: ^1.0.0
   intl: ^0.16.0
 
 dev_dependencies:
-  test: ^1.0.0
+  test: ^1.9.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
   sdk: ">=2.6.0 <3.0.0"
 dependencies:
   xml: ^3.0.0
-  http: ^0.11.1
+  http: ^0.12.1
   meta: ^1.0.0
   intl: ^0.16.0
 


### PR DESCRIPTION
Update http and test package dependencies to prevent resolution errors with other packages that depend upon a newer version of http. All tests and example pass.