### PR TITLE
Add PodcastIndex Live Item support

### DIFF
--- a/lib/domain/podcast_index/rss_podcast_index.dart
+++ b/lib/domain/podcast_index/rss_podcast_index.dart
@@ -1,4 +1,5 @@
 import 'package:dart_rss/domain/podcast_index/rss_podcast_index_funding.dart';
+import 'package:dart_rss/domain/podcast_index/rss_podcast_index_live_item.dart';
 import 'package:dart_rss/domain/podcast_index/rss_podcast_index_locked.dart';
 import 'package:dart_rss/domain/podcast_index/rss_podcast_index_person.dart';
 import 'package:dart_rss/util/helpers.dart';
@@ -15,10 +16,13 @@ class RssPodcastIndex {
   /// The purpose is to tell other podcast hosting platforms whether they are allowed to import this feed.
   final RssPodcastIndexLocked? locked;
 
+  final RssPodcastIndexLiveItem? liveItem;
+
   RssPodcastIndex({
     this.funding,
     this.persons,
     this.locked,
+    this.liveItem,
   });
 
   static RssPodcastIndex? parse(XmlElement? element) {
@@ -36,6 +40,8 @@ class RssPodcastIndex {
       locked: RssPodcastIndexLocked.parse(
         findElementOrNull(element, 'podcast:locked'),
       ),
+      liveItem: RssPodcastIndexLiveItem.parse(
+          findElementOrNull(element, "podcast:liveItem")),
     );
   }
 }

--- a/lib/domain/podcast_index/rss_podcast_index_alternate_enclosure.dart
+++ b/lib/domain/podcast_index/rss_podcast_index_alternate_enclosure.dart
@@ -1,0 +1,25 @@
+import 'package:dart_rss/util/helpers.dart';
+import 'package:xml/xml.dart';
+
+class RssPodcastIndexAlternateEnclosure {
+  final String? type;
+  final int? length;
+  final bool? isDefault;
+
+  RssPodcastIndexAlternateEnclosure(
+      {required this.type, required this.length, required this.isDefault});
+
+  static RssPodcastIndexAlternateEnclosure? parse(XmlElement? element) {
+    if (element == null) return null;
+    return RssPodcastIndexAlternateEnclosure(
+      type: element.getAttribute("type"),
+      length: parseInt(element.getAttribute("length")),
+      isDefault: parseBool(element.getAttribute("default")),
+    );
+  }
+
+  @override
+  String toString() {
+    return 'RssPodcastIndexAlternateEnclosure{type: $type, length: $length, isDefault: $isDefault}';
+  }
+}

--- a/lib/domain/podcast_index/rss_podcast_index_content_link.dart
+++ b/lib/domain/podcast_index/rss_podcast_index_content_link.dart
@@ -1,0 +1,20 @@
+import 'package:xml/xml.dart';
+
+class RssPodcastIndexContentLink {
+  final String? href;
+  final String? value;
+
+  RssPodcastIndexContentLink({this.href, this.value});
+
+  static RssPodcastIndexContentLink parse(XmlElement element) {
+    return RssPodcastIndexContentLink(
+      value: element.innerText,
+      href: element.getAttribute("href"),
+    );
+  }
+
+  @override
+  String toString() {
+    return 'RssPodcastIndexContentLink{href: $href, value: $value}';
+  }
+}

--- a/lib/domain/podcast_index/rss_podcast_index_guid.dart
+++ b/lib/domain/podcast_index/rss_podcast_index_guid.dart
@@ -1,0 +1,22 @@
+import 'package:dart_rss/util/helpers.dart';
+import 'package:xml/xml.dart';
+
+class RssPodcastIndexGuid {
+  final bool? isPermalink;
+  final String? value;
+
+  RssPodcastIndexGuid({this.isPermalink, this.value});
+
+  static RssPodcastIndexGuid? parse(XmlElement? element) {
+    if (element == null) return null;
+
+    return RssPodcastIndexGuid(
+        isPermalink: parseBool(element.getAttribute("isPermalink")),
+        value: element.innerText);
+  }
+
+  @override
+  String toString() {
+    return 'RssPodcastIndexGuid{isPermalink: $isPermalink, value: $value}';
+  }
+}

--- a/lib/domain/podcast_index/rss_podcast_index_live_item.dart
+++ b/lib/domain/podcast_index/rss_podcast_index_live_item.dart
@@ -1,0 +1,82 @@
+import 'package:dart_rss/domain/podcast_index/rss_podcast_index_alternate_enclosure.dart';
+import 'package:dart_rss/domain/podcast_index/rss_podcast_index_content_link.dart';
+import 'package:dart_rss/domain/podcast_index/rss_podcast_index_guid.dart';
+import 'package:dart_rss/domain/podcast_index/rss_podcast_index_person.dart';
+import 'package:dart_rss/domain/podcast_index/rss_podcast_live_item_images.dart';
+import 'package:dart_rss/domain/rss_enclosure.dart';
+import 'package:dart_rss/util/helpers.dart';
+import 'package:xml/xml.dart';
+
+class RssPodcastIndexLiveItem {
+  final String? title;
+  final String? description;
+  final String? link;
+  final String? author;
+
+  final String? status;
+  final String? start;
+  final String? end;
+
+  final RssPodcastIndexGuid? guid;
+  final RssPodcastIndexLiveItemImages? images;
+  final RssPodcastIndexAlternateEnclosure? alternateEnclosure;
+  final List<RssPodcastIndexPerson>? persons;
+  final RssEnclosure? enclosure;
+  final List<RssPodcastIndexContentLink>? contentLinks;
+
+  RssPodcastIndexLiveItem(
+      {this.title,
+      this.description,
+      this.link,
+      this.author,
+      this.status,
+      this.start,
+      this.end,
+      this.guid,
+      this.images,
+      this.alternateEnclosure,
+      this.persons,
+      this.enclosure,
+      this.contentLinks});
+
+  static RssPodcastIndexLiveItem? parse(XmlElement? element) {
+    if (element == null) return null;
+    return RssPodcastIndexLiveItem(
+      //elements
+      title: findElementOrNull(element, "title")?.innerText,
+      description: findElementOrNull(element, "description")?.innerText,
+      link: findElementOrNull(element, "link")?.innerText,
+      author: findElementOrNull(element, "author")?.innerText,
+
+      // attributes
+      status: element.getAttribute("status"),
+      start: element.getAttribute("start"),
+      end: element.getAttribute("end"),
+
+      // classes
+      guid: RssPodcastIndexGuid.parse(findElementOrNull(element, "guid")),
+
+      images: RssPodcastIndexLiveItemImages.parse(
+          findElementOrNull(element, "podcast:images")),
+
+      alternateEnclosure: RssPodcastIndexAlternateEnclosure.parse(
+          findElementOrNull(element, "podcast:alternateEnclosure")),
+
+      persons: element
+          .findElements('podcast:person')
+          .map((e) => RssPodcastIndexPerson.parse(e))
+          .toList(),
+      enclosure: RssEnclosure.parse(findElementOrNull(element, "enclosure")),
+
+      contentLinks: element
+          .findElements('podcast:contentLink')
+          .map((e) => RssPodcastIndexContentLink.parse(e))
+          .toList(),
+    );
+  }
+
+  @override
+  String toString() {
+    return 'RssPodcastIndexLiveItem{title: $title, description: $description, link: $link, author: $author, status: $status, start: $start, end: $end, guid: $guid, images: $images, alternateEnclosure: $alternateEnclosure, persons: $persons, enclosure: $enclosure, contentLinks: $contentLinks}';
+  }
+}

--- a/lib/domain/podcast_index/rss_podcast_index_live_item.dart
+++ b/lib/domain/podcast_index/rss_podcast_index_live_item.dart
@@ -4,6 +4,7 @@ import 'package:dart_rss/domain/podcast_index/rss_podcast_index_guid.dart';
 import 'package:dart_rss/domain/podcast_index/rss_podcast_index_person.dart';
 import 'package:dart_rss/domain/podcast_index/rss_podcast_live_item_images.dart';
 import 'package:dart_rss/domain/rss_enclosure.dart';
+import 'package:dart_rss/domain/rss_itunes_image.dart';
 import 'package:dart_rss/util/helpers.dart';
 import 'package:xml/xml.dart';
 
@@ -19,6 +20,7 @@ class RssPodcastIndexLiveItem {
 
   final RssPodcastIndexGuid? guid;
   final RssPodcastIndexLiveItemImages? images;
+  final RssItunesImage? itunesImage;
   final RssPodcastIndexAlternateEnclosure? alternateEnclosure;
   final List<RssPodcastIndexPerson>? persons;
   final RssEnclosure? enclosure;
@@ -34,6 +36,7 @@ class RssPodcastIndexLiveItem {
       this.end,
       this.guid,
       this.images,
+      this.itunesImage,
       this.alternateEnclosure,
       this.persons,
       this.enclosure,
@@ -59,6 +62,8 @@ class RssPodcastIndexLiveItem {
       images: RssPodcastIndexLiveItemImages.parse(
           findElementOrNull(element, "podcast:images")),
 
+      itunesImage:
+          RssItunesImage.parse(findElementOrNull(element, "itunes:image")),
       alternateEnclosure: RssPodcastIndexAlternateEnclosure.parse(
           findElementOrNull(element, "podcast:alternateEnclosure")),
 

--- a/lib/domain/podcast_index/rss_podcast_live_item_images.dart
+++ b/lib/domain/podcast_index/rss_podcast_live_item_images.dart
@@ -1,0 +1,27 @@
+import 'package:dart_rss/util/helpers.dart';
+import 'package:xml/xml.dart';
+
+class RssPodcastIndexLiveItemImages {
+  final List<String>? urls;
+
+  RssPodcastIndexLiveItemImages({required this.urls});
+
+  static RssPodcastIndexLiveItemImages? parse(XmlElement? element) {
+    if (element == null) {
+      return null;
+    }
+
+    final imagesElement = element.getAttribute("srcset");
+    if (imagesElement == null) return RssPodcastIndexLiveItemImages(urls: null);
+    final urls = imagesElement
+        .split(",")
+        .map((e) => RegExp(r"^[s]+").firstMatch(e).toString())
+        .toList();
+    return RssPodcastIndexLiveItemImages(urls: urls);
+  }
+
+  @override
+  String toString() {
+    return 'RssPodcastLiveItemImages{urls: $urls}';
+  }
+}

--- a/lib/domain/podcast_index/rss_podcast_live_item_images.dart
+++ b/lib/domain/podcast_index/rss_podcast_live_item_images.dart
@@ -15,7 +15,7 @@ class RssPodcastIndexLiveItemImages {
     if (imagesElement == null) return RssPodcastIndexLiveItemImages(urls: null);
     final urls = imagesElement
         .split(",")
-        .map((e) => RegExp(r"^[s]+").firstMatch(e).toString())
+        .map((e) => RegExp(r"^[^s]+").firstMatch(e).toString())
         .toList();
     return RssPodcastIndexLiveItemImages(urls: urls);
   }

--- a/lib/util/helpers.dart
+++ b/lib/util/helpers.dart
@@ -26,6 +26,11 @@ bool? parseBoolLiteral(XmlElement element, String tagName) {
   return ['yes', 'true'].contains(v);
 }
 
+bool? parseBool(String? v) {
+  if (v == null) return null;
+  return ['yes', 'true'].contains(v);
+}
+
 DateTime? parseDateTime(String? dateTimeString) {
   if (dateTimeString == null) return null;
   return DateTime.tryParse(dateTimeString);


### PR DESCRIPTION
See [Podcast Index's entry on the `liveItem` tag](https://github.com/Podcastindex-org/podcast-namespace/blob/main/docs/1.0.md#live-item)

Wasn't positive whether to include `itunes:image` or not, but I saw it on multiple test RSS feeds.