### PR TITLE
Bump http dependency version (Resolves #35)

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   xml: ^6.3.0
-  http: ^0.13.0
+  http: ^1.1.2
   intl: ^0.18.0
 
 dev_dependencies:


### PR DESCRIPTION
Bump http dependency version. Resolves #35

The package depends on http version `^0.13.0`. This makes it incompatible with apps/packages that depend on http `^1.1.0`

This PR bumps the http dependency to the latest version.