### PR TITLE
Add support for liveItem parsing within the podcast extension (Resolves #39)

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -5,3 +5,6 @@ linter:
     - always_use_package_imports
     - avoid_print
     - curly_braces_in_flow_control_structures
+    - prefer_const_constructors
+    - prefer_const_constructors_in_immutables
+    - prefer_const_declarations

--- a/lib/dart_rss.dart
+++ b/lib/dart_rss.dart
@@ -12,3 +12,17 @@ export 'domain/rss_feed.dart';
 export 'domain/rss_image.dart';
 export 'domain/rss_item.dart';
 export 'domain/rss_source.dart';
+
+// Podcasts
+export 'domain/podcast_index/rss_podcast_index.dart';
+export 'domain/podcast_index/rss_podcast_index_alternate_enclosure.dart';
+export 'domain/podcast_index/rss_podcast_index_chapters.dart';
+export 'domain/podcast_index/rss_podcast_index_content_link.dart';
+export 'domain/podcast_index/rss_podcast_index_funding.dart';
+export 'domain/podcast_index/rss_podcast_index_guid.dart';
+export 'domain/podcast_index/rss_podcast_index_live_item.dart';
+export 'domain/podcast_index/rss_podcast_index_locked.dart';
+export 'domain/podcast_index/rss_podcast_index_person.dart';
+export 'domain/podcast_index/rss_podcast_index_soudbite.dart';
+export 'domain/podcast_index/rss_podcast_index_transcript.dart';
+export 'domain/podcast_index/rss_podcast_live_item_images.dart';

--- a/lib/domain/podcast_index/rss_podcast_index.dart
+++ b/lib/domain/podcast_index/rss_podcast_index.dart
@@ -22,9 +22,9 @@ class RssPodcastIndex {
       locked: RssPodcastIndexLocked.parse(
         findElementOrNull(element, 'podcast:locked'),
       ),
-      liveItem: RssPodcastIndexLiveItem.parse(
-        findElementOrNull(element, "podcast:liveItem"),
-      ),
+      liveItems: element.findElements('podcast:liveItem').map((e) {
+        return RssPodcastIndexLiveItem.parse(e);
+      }).toList(),
     );
   }
 
@@ -32,7 +32,7 @@ class RssPodcastIndex {
     this.funding,
     this.persons,
     this.locked,
-    this.liveItem,
+    this.liveItems,
   });
 
   /// List of funding tags.
@@ -44,5 +44,5 @@ class RssPodcastIndex {
   /// The purpose is to tell other podcast hosting platforms whether they are allowed to import this feed.
   final RssPodcastIndexLocked? locked;
 
-  final RssPodcastIndexLiveItem? liveItem;
+  final List<RssPodcastIndexLiveItem?>? liveItems;
 }

--- a/lib/domain/podcast_index/rss_podcast_index.dart
+++ b/lib/domain/podcast_index/rss_podcast_index.dart
@@ -1,4 +1,5 @@
 import 'package:dart_rss/domain/podcast_index/rss_podcast_index_funding.dart';
+import 'package:dart_rss/domain/podcast_index/rss_podcast_index_live_item.dart';
 import 'package:dart_rss/domain/podcast_index/rss_podcast_index_locked.dart';
 import 'package:dart_rss/domain/podcast_index/rss_podcast_index_person.dart';
 import 'package:dart_rss/util/helpers.dart';
@@ -21,6 +22,9 @@ class RssPodcastIndex {
       locked: RssPodcastIndexLocked.parse(
         findElementOrNull(element, 'podcast:locked'),
       ),
+      liveItem: RssPodcastIndexLiveItem.parse(
+        findElementOrNull(element, "podcast:liveItem"),
+      ),
     );
   }
 
@@ -28,6 +32,7 @@ class RssPodcastIndex {
     this.funding,
     this.persons,
     this.locked,
+    this.liveItem,
   });
 
   /// List of funding tags.
@@ -38,4 +43,6 @@ class RssPodcastIndex {
 
   /// The purpose is to tell other podcast hosting platforms whether they are allowed to import this feed.
   final RssPodcastIndexLocked? locked;
+
+  final RssPodcastIndexLiveItem? liveItem;
 }

--- a/lib/domain/podcast_index/rss_podcast_index_alternate_enclosure.dart
+++ b/lib/domain/podcast_index/rss_podcast_index_alternate_enclosure.dart
@@ -1,6 +1,10 @@
 import 'package:dart_rss/util/helpers.dart';
 import 'package:xml/xml.dart';
 
+// TODO: Complete the definition for the "alternativeEnclosure" tag (
+/// The `alternativeEnclosure` XML element.
+///
+/// https://github.com/Podcastindex-org/podcast-namespace/blob/main/docs/1.0.md#alternate-enclosure
 class RssPodcastIndexAlternateEnclosure {
   static RssPodcastIndexAlternateEnclosure? parse(XmlElement? element) {
     if (element == null) {

--- a/lib/domain/podcast_index/rss_podcast_index_alternate_enclosure.dart
+++ b/lib/domain/podcast_index/rss_podcast_index_alternate_enclosure.dart
@@ -1,0 +1,31 @@
+import 'package:dart_rss/util/helpers.dart';
+import 'package:xml/xml.dart';
+
+class RssPodcastIndexAlternateEnclosure {
+  static RssPodcastIndexAlternateEnclosure? parse(XmlElement? element) {
+    if (element == null) {
+      return null;
+    }
+
+    return RssPodcastIndexAlternateEnclosure(
+      type: element.getAttribute("type"),
+      length: parseInt(element.getAttribute("length")),
+      isDefault: parseBool(element.getAttribute("default")),
+    );
+  }
+
+  const RssPodcastIndexAlternateEnclosure({
+    required this.type,
+    required this.length,
+    required this.isDefault,
+  });
+
+  final String? type;
+  final int? length;
+  final bool? isDefault;
+
+  @override
+  String toString() {
+    return 'RssPodcastIndexAlternateEnclosure{type: $type, length: $length, isDefault: $isDefault}';
+  }
+}

--- a/lib/domain/podcast_index/rss_podcast_index_content_link.dart
+++ b/lib/domain/podcast_index/rss_podcast_index_content_link.dart
@@ -1,0 +1,23 @@
+import 'package:xml/xml.dart';
+
+class RssPodcastIndexContentLink {
+  static RssPodcastIndexContentLink parse(XmlElement element) {
+    return RssPodcastIndexContentLink(
+      value: element.innerText,
+      href: element.getAttribute("href"),
+    );
+  }
+
+  const RssPodcastIndexContentLink({
+    this.href,
+    this.value,
+  });
+
+  final String? href;
+  final String? value;
+
+  @override
+  String toString() {
+    return 'RssPodcastIndexContentLink{href: $href, value: $value}';
+  }
+}

--- a/lib/domain/podcast_index/rss_podcast_index_guid.dart
+++ b/lib/domain/podcast_index/rss_podcast_index_guid.dart
@@ -1,0 +1,28 @@
+import 'package:dart_rss/util/helpers.dart';
+import 'package:xml/xml.dart';
+
+class RssPodcastIndexGuid {
+  static RssPodcastIndexGuid? parse(XmlElement? element) {
+    if (element == null) {
+      return null;
+    }
+
+    return RssPodcastIndexGuid(
+      isPermalink: parseBool(element.getAttribute("isPermalink")),
+      value: element.innerText,
+    );
+  }
+
+  const RssPodcastIndexGuid({
+    this.isPermalink,
+    this.value,
+  });
+
+  final bool? isPermalink;
+  final String? value;
+
+  @override
+  String toString() {
+    return 'RssPodcastIndexGuid{isPermalink: $isPermalink, value: $value}';
+  }
+}

--- a/lib/domain/podcast_index/rss_podcast_index_guid.dart
+++ b/lib/domain/podcast_index/rss_podcast_index_guid.dart
@@ -8,7 +8,7 @@ class RssPodcastIndexGuid {
     }
 
     return RssPodcastIndexGuid(
-      isPermalink: parseBool(element.getAttribute("isPermalink")),
+      isPermalink: parseBool(element.getAttribute("isPermaLink")),
       value: element.innerText,
     );
   }

--- a/lib/domain/podcast_index/rss_podcast_index_live_item.dart
+++ b/lib/domain/podcast_index/rss_podcast_index_live_item.dart
@@ -8,6 +8,9 @@ import 'package:dart_rss/domain/rss_itunes_image.dart';
 import 'package:dart_rss/util/helpers.dart';
 import 'package:xml/xml.dart';
 
+/// The `liveItem` XML element.
+///
+/// https://github.com/Podcastindex-org/podcast-namespace/blob/main/docs/1.0.md#live-item
 class RssPodcastIndexLiveItem {
   static RssPodcastIndexLiveItem? parse(XmlElement? element) {
     if (element == null) {

--- a/lib/domain/podcast_index/rss_podcast_index_live_item.dart
+++ b/lib/domain/podcast_index/rss_podcast_index_live_item.dart
@@ -1,0 +1,84 @@
+import 'package:dart_rss/domain/podcast_index/rss_podcast_index_alternate_enclosure.dart';
+import 'package:dart_rss/domain/podcast_index/rss_podcast_index_content_link.dart';
+import 'package:dart_rss/domain/podcast_index/rss_podcast_index_guid.dart';
+import 'package:dart_rss/domain/podcast_index/rss_podcast_index_person.dart';
+import 'package:dart_rss/domain/podcast_index/rss_podcast_live_item_images.dart';
+import 'package:dart_rss/domain/rss_enclosure.dart';
+import 'package:dart_rss/domain/rss_itunes_image.dart';
+import 'package:dart_rss/util/helpers.dart';
+import 'package:xml/xml.dart';
+
+class RssPodcastIndexLiveItem {
+  static RssPodcastIndexLiveItem? parse(XmlElement? element) {
+    if (element == null) {
+      return null;
+    }
+
+    return RssPodcastIndexLiveItem(
+      //elements
+      title: findElementOrNull(element, "title")?.innerText,
+      description: findElementOrNull(element, "description")?.innerText,
+      link: findElementOrNull(element, "link")?.innerText,
+      author: findElementOrNull(element, "author")?.innerText,
+
+      // attributes
+      status: element.getAttribute("status"),
+      start: element.getAttribute("start"),
+      end: element.getAttribute("end"),
+
+      // classes
+      guid: RssPodcastIndexGuid.parse(findElementOrNull(element, "guid")),
+
+      images: RssPodcastIndexLiveItemImages.parse(findElementOrNull(element, "podcast:images")),
+
+      itunesImage: RssItunesImage.parse(findElementOrNull(element, "itunes:image")),
+      alternateEnclosure:
+          RssPodcastIndexAlternateEnclosure.parse(findElementOrNull(element, "podcast:alternateEnclosure")),
+
+      persons: element.findElements('podcast:person').map((e) => RssPodcastIndexPerson.parse(e)).toList(),
+      enclosure: RssEnclosure.parse(findElementOrNull(element, "enclosure")),
+
+      contentLinks:
+          element.findElements('podcast:contentLink').map((e) => RssPodcastIndexContentLink.parse(e)).toList(),
+    );
+  }
+
+  const RssPodcastIndexLiveItem({
+    this.title,
+    this.description,
+    this.link,
+    this.author,
+    this.status,
+    this.start,
+    this.end,
+    this.guid,
+    this.images,
+    this.itunesImage,
+    this.alternateEnclosure,
+    this.persons,
+    this.enclosure,
+    this.contentLinks,
+  });
+
+  final String? title;
+  final String? description;
+  final String? link;
+  final String? author;
+
+  final String? status;
+  final String? start;
+  final String? end;
+
+  final RssPodcastIndexGuid? guid;
+  final RssPodcastIndexLiveItemImages? images;
+  final RssItunesImage? itunesImage;
+  final RssPodcastIndexAlternateEnclosure? alternateEnclosure;
+  final List<RssPodcastIndexPerson>? persons;
+  final RssEnclosure? enclosure;
+  final List<RssPodcastIndexContentLink>? contentLinks;
+
+  @override
+  String toString() {
+    return 'RssPodcastIndexLiveItem{title: $title, description: $description, link: $link, author: $author, status: $status, start: $start, end: $end, guid: $guid, images: $images, alternateEnclosure: $alternateEnclosure, persons: $persons, enclosure: $enclosure, contentLinks: $contentLinks}';
+  }
+}

--- a/lib/domain/podcast_index/rss_podcast_live_item_images.dart
+++ b/lib/domain/podcast_index/rss_podcast_live_item_images.dart
@@ -1,0 +1,25 @@
+import 'package:xml/xml.dart';
+
+class RssPodcastIndexLiveItemImages {
+  static RssPodcastIndexLiveItemImages? parse(XmlElement? element) {
+    if (element == null) {
+      return null;
+    }
+
+    final imagesElement = element.getAttribute("srcset");
+    if (imagesElement == null) {
+      return const RssPodcastIndexLiveItemImages(urls: null);
+    }
+    final urls = imagesElement.split(",").map((e) => RegExp(r"^[^s]+").firstMatch(e).toString()).toList();
+    return RssPodcastIndexLiveItemImages(urls: urls);
+  }
+
+  const RssPodcastIndexLiveItemImages({required this.urls});
+
+  final List<String>? urls;
+
+  @override
+  String toString() {
+    return 'RssPodcastLiveItemImages{urls: $urls}';
+  }
+}

--- a/lib/domain/rss_feed.dart
+++ b/lib/domain/rss_feed.dart
@@ -105,5 +105,9 @@ class RssFeed {
   final int ttl;
   final DublinCore? dc;
   final RssItunes? itunes;
+
+  // TODO: Rework the model for RssPodcastIndex. This looks like an artificial construct that was
+  //       introduced to hold podcast extensions, even though some/all of those extensions are
+  //       supposed to be able to apply directly to a channel.
   final RssPodcastIndex? podcastIndex;
 }

--- a/lib/util/helpers.dart
+++ b/lib/util/helpers.dart
@@ -21,12 +21,16 @@ List<XmlElement>? findAllDirectElementsOrNull(XmlElement element, String name, {
 
 bool? parseBoolLiteral(XmlElement element, String tagName) {
   final v = findElementOrNull(element, tagName)?.innerText.toLowerCase().trim();
-  if (v == null) return null;
+  if (v == null) {
+    return null;
+  }
   return ['yes', 'true'].contains(v);
 }
 
 bool? parseBool(String? v) {
-  if (v == null) return null;
+  if (v == null) {
+    return null;
+  }
   return ['yes', 'true'].contains(v);
 }
 
@@ -58,11 +62,15 @@ extension SafeParseDateTime on DateTime {
 }
 
 DateTime? parseDateTime(String? dateTimeString) {
-  if (dateTimeString == null) return null;
+  if (dateTimeString == null) {
+    return null;
+  }
   return DateTime.tryParse(dateTimeString);
 }
 
 int? parseInt(String? intString) {
-  if (intString == null) return null;
+  if (intString == null) {
+    return null;
+  }
   return int.tryParse(intString);
 }

--- a/lib/util/helpers.dart
+++ b/lib/util/helpers.dart
@@ -25,6 +25,11 @@ bool? parseBoolLiteral(XmlElement element, String tagName) {
   return ['yes', 'true'].contains(v);
 }
 
+bool? parseBool(String? v) {
+  if (v == null) return null;
+  return ['yes', 'true'].contains(v);
+}
+
 extension SafeParseDateTime on DateTime {
   static DateTime? safeParse(String? str) {
     if (str == null) {

--- a/test/rss1_test.dart
+++ b/test/rss1_test.dart
@@ -83,7 +83,7 @@ void main() {
     );
     expect(
       firstItem.content!.images,
-      Iterable.empty(),
+      const Iterable.empty(),
     );
   });
 

--- a/test/rss_test.dart
+++ b/test/rss_test.dart
@@ -384,8 +384,8 @@ void main() {
     expect(feed.podcastIndex!.liveItems, isNotNull);
     expect(feed.podcastIndex!.liveItems!.length, 3);
     _verifyLiveItem0(feed.podcastIndex!.liveItems![0]!);
-    _verifyLiveItem0(feed.podcastIndex!.liveItems![1]!);
-    _verifyLiveItem0(feed.podcastIndex!.liveItems![2]!);
+    _verifyLiveItem1(feed.podcastIndex!.liveItems![1]!);
+    _verifyLiveItem2(feed.podcastIndex!.liveItems![2]!);
 
     var item1 = feed.items[0];
     var transcripts1 = item1.podcastIndex!.transcripts;

--- a/test/rss_test.dart
+++ b/test/rss_test.dart
@@ -345,7 +345,7 @@ void main() {
     expect(item.itunes!.episode, 1);
     expect(item.itunes!.season, 1);
     expect(item.itunes!.image!.href, 'https://cdn.changelog.com/uploads/covers/go-time-original.png?v=63725770357');
-    expect(item.itunes!.duration, Duration(minutes: 32, seconds: 30));
+    expect(item.itunes!.duration, const Duration(minutes: 32, seconds: 30));
     expect(item.itunes!.explicit, false);
     expect(item.itunes!.keywords, 'go,golang,open source,software,development'.split(','));
     expect(item.itunes!.subtitle, 'with Erik, Carlisia, and Brian');

--- a/test/rss_test.dart
+++ b/test/rss_test.dart
@@ -381,6 +381,12 @@ void main() {
     expect(feed.podcastIndex!.funding![1]!.url, 'https://example.com/member');
     expect(feed.podcastIndex!.funding![1]!.value, 'Become a member!');
 
+    expect(feed.podcastIndex!.liveItems, isNotNull);
+    expect(feed.podcastIndex!.liveItems!.length, 3);
+    _verifyLiveItem0(feed.podcastIndex!.liveItems![0]!);
+    _verifyLiveItem0(feed.podcastIndex!.liveItems![1]!);
+    _verifyLiveItem0(feed.podcastIndex!.liveItems![2]!);
+
     var item1 = feed.items[0];
     var transcripts1 = item1.podcastIndex!.transcripts;
     var soundbite1 = item1.podcastIndex!.soundbites;
@@ -415,4 +421,178 @@ void main() {
     expect(soundbite2[0]!.startTime, 45.4);
     expect(soundbite2[0]!.duration, 56.0);
   });
+}
+
+void _verifyLiveItem0(RssPodcastIndexLiveItem liveItem) {
+  expect(liveItem.status, "pending");
+  expect(liveItem.start, "2025-05-14T13:00:00.000-0800");
+  expect(liveItem.end, isNull);
+  expect(liveItem.title, "A Future Show");
+  expect(liveItem.description, "This entry represents a show that will happen in the future.");
+  expect(liveItem.link, "https://example.com/podcast/live");
+  expect(liveItem.guid!.isPermalink, true);
+  expect(liveItem.guid!.value, "https://example.com/live");
+  expect(liveItem.author, "John Doe (john@example.com)");
+  expect(liveItem.images, isNotNull);
+  // TODO: check image parsing and find out why it doesn't support our situation
+  // expect(
+  //   liveItem.images!.urls,
+  //   "https://example.com/images/live/pci_avatar-massive.jpg 1500w, https://example.com/images/live/pci_avatar-middle.jpg 600w, https://example.com/images/live/pci_avatar-small.jpg 300w, https://example.com/images/live/pci_avatar-tiny.jpg 150w",
+  // );
+
+  // <podcast:images srcset="https://example.com/images/live/pci_avatar-massive.jpg 1500w,
+  // https://example.com/images/live/pci_avatar-middle.jpg 600w,
+  // https://example.com/images/live/pci_avatar-small.jpg 300w,
+  // https://example.com/images/live/pci_avatar-tiny.jpg 150w"
+  // />
+  expect(liveItem.persons!.length, 3);
+  expect(liveItem.persons![0].name, "Adam Curry");
+  expect(liveItem.persons![0].link, "https://www.podchaser.com/creators/adam-curry-107ZzmWE5f");
+  expect(liveItem.persons![0].image, "https://example.com/images/adamcurry.jpg");
+
+  expect(liveItem.persons![1].name, "Dave Jones");
+  expect(liveItem.persons![1].link, "https://github.com/daveajones/");
+  expect(liveItem.persons![1].image, "https://example.com/images/davejones.jpg");
+  expect(liveItem.persons![1].role, "guest");
+
+  expect(liveItem.persons![2].name, "Becky Smith");
+  expect(liveItem.persons![2].link, "https://example.com/artist/beckysmith");
+  expect(liveItem.persons![2].group, "visuals");
+  expect(liveItem.persons![2].role, "cover art designer");
+
+  expect(liveItem.alternateEnclosure, isNotNull);
+  expect(liveItem.alternateEnclosure!.type, "audio/mpeg");
+  expect(liveItem.alternateEnclosure!.length, 312);
+  expect(liveItem.alternateEnclosure!.isDefault, true);
+  // TODO: test the rest of the alernativeEnclosure when we finish modeling it (#43)
+
+  expect(liveItem.enclosure, isNotNull);
+  expect(liveItem.enclosure!.url, "https://example.com/pc20/livestream?format=.mp3");
+  expect(liveItem.enclosure!.type, "audio/mpeg");
+  expect(liveItem.enclosure!.length, 312);
+
+  expect(liveItem.contentLinks, isNotNull);
+  expect(liveItem.contentLinks!.length, 3);
+  expect(liveItem.contentLinks![0].href, "https://youtube.com/pc20/livestream");
+  expect(liveItem.contentLinks![0].value, "YouTube!");
+  expect(liveItem.contentLinks![1].href, "https://twitch.com/pc20/livestream");
+  expect(liveItem.contentLinks![1].value, "Twitch!");
+  expect(liveItem.contentLinks![2].href, "https://example.com/html/livestream");
+  expect(liveItem.contentLinks![2].value, "Listen Live!");
+}
+
+void _verifyLiveItem1(RssPodcastIndexLiveItem liveItem) {
+  expect(liveItem.status, "live");
+  expect(liveItem.start, "2023-01-13T13:00:00.000-0800");
+  expect(liveItem.end, isNull);
+  expect(liveItem.title, "An In-Progress Show");
+  expect(liveItem.description, "This entry represents a show that's happening right now.");
+  expect(liveItem.link, "https://example.com/podcast/live");
+  expect(liveItem.guid!.isPermalink, true);
+  expect(liveItem.guid!.value, "https://example.com/live");
+  expect(liveItem.author, "John Doe (john@example.com)");
+  expect(liveItem.images, isNotNull);
+  // TODO: check image parsing and find out why it doesn't support our situation
+  // expect(
+  //   liveItem.images!.urls,
+  //   "https://example.com/images/live/pci_avatar-massive.jpg 1500w, https://example.com/images/live/pci_avatar-middle.jpg 600w, https://example.com/images/live/pci_avatar-small.jpg 300w, https://example.com/images/live/pci_avatar-tiny.jpg 150w",
+  // );
+
+  // <podcast:images srcset="https://example.com/images/live/pci_avatar-massive.jpg 1500w,
+  // https://example.com/images/live/pci_avatar-middle.jpg 600w,
+  // https://example.com/images/live/pci_avatar-small.jpg 300w,
+  // https://example.com/images/live/pci_avatar-tiny.jpg 150w"
+  // />
+  expect(liveItem.persons!.length, 3);
+  expect(liveItem.persons![0].name, "Adam Curry");
+  expect(liveItem.persons![0].link, "https://www.podchaser.com/creators/adam-curry-107ZzmWE5f");
+  expect(liveItem.persons![0].image, "https://example.com/images/adamcurry.jpg");
+
+  expect(liveItem.persons![1].name, "Dave Jones");
+  expect(liveItem.persons![1].link, "https://github.com/daveajones/");
+  expect(liveItem.persons![1].image, "https://example.com/images/davejones.jpg");
+  expect(liveItem.persons![1].role, "guest");
+
+  expect(liveItem.persons![2].name, "Becky Smith");
+  expect(liveItem.persons![2].link, "https://example.com/artist/beckysmith");
+  expect(liveItem.persons![2].group, "visuals");
+  expect(liveItem.persons![2].role, "cover art designer");
+
+  expect(liveItem.alternateEnclosure, isNotNull);
+  expect(liveItem.alternateEnclosure!.type, "audio/mpeg");
+  expect(liveItem.alternateEnclosure!.length, 312);
+  expect(liveItem.alternateEnclosure!.isDefault, true);
+  // TODO: test the rest of the alernativeEnclosure when we finish modeling it (#43)
+
+  expect(liveItem.enclosure, isNotNull);
+  expect(liveItem.enclosure!.url, "https://example.com/pc20/livestream?format=.mp3");
+  expect(liveItem.enclosure!.type, "audio/mpeg");
+  expect(liveItem.enclosure!.length, 312);
+
+  expect(liveItem.contentLinks, isNotNull);
+  expect(liveItem.contentLinks!.length, 3);
+  expect(liveItem.contentLinks![0].href, "https://youtube.com/pc20/livestream");
+  expect(liveItem.contentLinks![0].value, "YouTube!");
+  expect(liveItem.contentLinks![1].href, "https://twitch.com/pc20/livestream");
+  expect(liveItem.contentLinks![1].value, "Twitch!");
+  expect(liveItem.contentLinks![2].href, "https://example.com/html/livestream");
+  expect(liveItem.contentLinks![2].value, "Listen Live!");
+}
+
+void _verifyLiveItem2(RssPodcastIndexLiveItem liveItem) {
+  expect(liveItem.status, "ended");
+  expect(liveItem.start, "2020-08-26T13:00:00.000-0800");
+  expect(liveItem.end, "2020-08-26T15:00:00.000-0800");
+  expect(liveItem.title, "A Completed Show");
+  expect(liveItem.description, "This entry represents a show that was recorded in the past.");
+  expect(liveItem.link, "https://example.com/podcast/live");
+  expect(liveItem.guid!.isPermalink, true);
+  expect(liveItem.guid!.value, "https://example.com/live");
+  expect(liveItem.author, "John Doe (john@example.com)");
+  expect(liveItem.images, isNotNull);
+  // TODO: check image parsing and find out why it doesn't support our situation
+  // expect(
+  //   liveItem.images!.urls,
+  //   "https://example.com/images/live/pci_avatar-massive.jpg 1500w, https://example.com/images/live/pci_avatar-middle.jpg 600w, https://example.com/images/live/pci_avatar-small.jpg 300w, https://example.com/images/live/pci_avatar-tiny.jpg 150w",
+  // );
+
+  // <podcast:images srcset="https://example.com/images/live/pci_avatar-massive.jpg 1500w,
+  // https://example.com/images/live/pci_avatar-middle.jpg 600w,
+  // https://example.com/images/live/pci_avatar-small.jpg 300w,
+  // https://example.com/images/live/pci_avatar-tiny.jpg 150w"
+  // />
+  expect(liveItem.persons!.length, 3);
+  expect(liveItem.persons![0].name, "Adam Curry");
+  expect(liveItem.persons![0].link, "https://www.podchaser.com/creators/adam-curry-107ZzmWE5f");
+  expect(liveItem.persons![0].image, "https://example.com/images/adamcurry.jpg");
+
+  expect(liveItem.persons![1].name, "Dave Jones");
+  expect(liveItem.persons![1].link, "https://github.com/daveajones/");
+  expect(liveItem.persons![1].image, "https://example.com/images/davejones.jpg");
+  expect(liveItem.persons![1].role, "guest");
+
+  expect(liveItem.persons![2].name, "Becky Smith");
+  expect(liveItem.persons![2].link, "https://example.com/artist/beckysmith");
+  expect(liveItem.persons![2].group, "visuals");
+  expect(liveItem.persons![2].role, "cover art designer");
+
+  expect(liveItem.alternateEnclosure, isNotNull);
+  expect(liveItem.alternateEnclosure!.type, "audio/mpeg");
+  expect(liveItem.alternateEnclosure!.length, 312);
+  expect(liveItem.alternateEnclosure!.isDefault, true);
+  // TODO: test the rest of the alernativeEnclosure when we finish modeling it (#43)
+
+  expect(liveItem.enclosure, isNotNull);
+  expect(liveItem.enclosure!.url, "https://example.com/pc20/livestream?format=.mp3");
+  expect(liveItem.enclosure!.type, "audio/mpeg");
+  expect(liveItem.enclosure!.length, 312);
+
+  expect(liveItem.contentLinks, isNotNull);
+  expect(liveItem.contentLinks!.length, 3);
+  expect(liveItem.contentLinks![0].href, "https://youtube.com/pc20/livestream");
+  expect(liveItem.contentLinks![0].value, "YouTube!");
+  expect(liveItem.contentLinks![1].href, "https://twitch.com/pc20/livestream");
+  expect(liveItem.contentLinks![1].value, "Twitch!");
+  expect(liveItem.contentLinks![2].href, "https://example.com/html/livestream");
+  expect(liveItem.contentLinks![2].value, "Listen Live!");
 }

--- a/test/xml/RSS-PodcastIndex-R1.xml
+++ b/test/xml/RSS-PodcastIndex-R1.xml
@@ -61,6 +61,84 @@
             <podcast:valueRecipient name="hosting company" type="node" address="036557ea56b3b86f08be31bcd2557cae8021b0e3a9413f0c0e52625c6696972e57" split="1" />
         </podcast:value>
 
+        <podcast:liveItem status="pending" start="2025-05-14T13:00:00.000-0800">
+            <title>A Future Show</title>
+            <description>This entry represents a show that will happen in the future.</description>
+            <link>https://example.com/podcast/live</link>
+            <guid isPermaLink="true">https://example.com/live</guid>
+            <author>John Doe (john@example.com)</author>
+            <podcast:images srcset="https://example.com/images/live/pci_avatar-massive.jpg 1500w,
+                https://example.com/images/live/pci_avatar-middle.jpg 600w,
+                https://example.com/images/live/pci_avatar-small.jpg 300w,
+                https://example.com/images/live/pci_avatar-tiny.jpg 150w"
+                />
+            <podcast:person href="https://www.podchaser.com/creators/adam-curry-107ZzmWE5f"
+                img="https://example.com/images/adamcurry.jpg">Adam Curry</podcast:person>
+            <podcast:person role="guest" href="https://github.com/daveajones/"
+                img="https://example.com/images/davejones.jpg">Dave Jones</podcast:person>
+            <podcast:person group="visuals" role="cover art designer"
+                href="https://example.com/artist/beckysmith">Becky Smith</podcast:person>
+            <podcast:alternateEnclosure type="audio/mpeg" length="312" default="true">
+                <podcast:source uri="https://example.com/pc20/livestream" />
+            </podcast:alternateEnclosure>
+            <enclosure url="https://example.com/pc20/livestream?format=.mp3" type="audio/mpeg" length="312" />
+            <podcast:contentLink href="https://youtube.com/pc20/livestream">YouTube!</podcast:contentLink>
+            <podcast:contentLink href="https://twitch.com/pc20/livestream">Twitch!</podcast:contentLink>
+            <podcast:contentLink href="https://example.com/html/livestream">Listen Live!</podcast:contentLink>
+        </podcast:liveItem>
+
+        <podcast:liveItem status="live" start="2023-01-13T13:00:00.000-0800">
+            <title>An In-Progress Show</title>
+            <description>This entry represents a show that's happening right now.</description>
+            <link>https://example.com/podcast/live</link>
+            <guid isPermaLink="true">https://example.com/live</guid>
+            <author>John Doe (john@example.com)</author>
+            <podcast:images srcset="https://example.com/images/live/pci_avatar-massive.jpg 1500w,
+                https://example.com/images/live/pci_avatar-middle.jpg 600w,
+                https://example.com/images/live/pci_avatar-small.jpg 300w,
+                https://example.com/images/live/pci_avatar-tiny.jpg 150w"
+                />
+            <podcast:person href="https://www.podchaser.com/creators/adam-curry-107ZzmWE5f"
+                img="https://example.com/images/adamcurry.jpg">Adam Curry</podcast:person>
+            <podcast:person role="guest" href="https://github.com/daveajones/"
+                img="https://example.com/images/davejones.jpg">Dave Jones</podcast:person>
+            <podcast:person group="visuals" role="cover art designer"
+                href="https://example.com/artist/beckysmith">Becky Smith</podcast:person>
+            <podcast:alternateEnclosure type="audio/mpeg" length="312" default="true">
+                <podcast:source uri="https://example.com/pc20/livestream" />
+            </podcast:alternateEnclosure>
+            <enclosure url="https://example.com/pc20/livestream?format=.mp3" type="audio/mpeg" length="312" />
+            <podcast:contentLink href="https://youtube.com/pc20/livestream">YouTube!</podcast:contentLink>
+            <podcast:contentLink href="https://twitch.com/pc20/livestream">Twitch!</podcast:contentLink>
+            <podcast:contentLink href="https://example.com/html/livestream">Listen Live!</podcast:contentLink>
+        </podcast:liveItem>
+
+        <podcast:liveItem status="ended" start="2020-08-26T13:00:00.000-0800" end="2020-08-26T15:00:00.000-0800">
+            <title>A Completed Show</title>
+            <description>This entry represents a show that was recorded in the past.</description>
+            <link>https://example.com/podcast/live</link>
+            <guid isPermaLink="true">https://example.com/live</guid>
+            <author>John Doe (john@example.com)</author>
+            <podcast:images srcset="https://example.com/images/live/pci_avatar-massive.jpg 1500w,
+                https://example.com/images/live/pci_avatar-middle.jpg 600w,
+                https://example.com/images/live/pci_avatar-small.jpg 300w,
+                https://example.com/images/live/pci_avatar-tiny.jpg 150w"
+                />
+            <podcast:person href="https://www.podchaser.com/creators/adam-curry-107ZzmWE5f"
+                img="https://example.com/images/adamcurry.jpg">Adam Curry</podcast:person>
+            <podcast:person role="guest" href="https://github.com/daveajones/"
+                img="https://example.com/images/davejones.jpg">Dave Jones</podcast:person>
+            <podcast:person group="visuals" role="cover art designer"
+                href="https://example.com/artist/beckysmith">Becky Smith</podcast:person>
+            <podcast:alternateEnclosure type="audio/mpeg" length="312" default="true">
+                <podcast:source uri="https://example.com/pc20/livestream" />
+            </podcast:alternateEnclosure>
+            <enclosure url="https://example.com/pc20/livestream?format=.mp3" type="audio/mpeg" length="312" />
+            <podcast:contentLink href="https://youtube.com/pc20/livestream">YouTube!</podcast:contentLink>
+            <podcast:contentLink href="https://twitch.com/pc20/livestream">Twitch!</podcast:contentLink>
+            <podcast:contentLink href="https://example.com/html/livestream">Listen Live!</podcast:contentLink>
+        </podcast:liveItem>
+
         <item>
             <title>Episode 3 - The Future</title>
             <description>&lt;p&gt;A look into the future of podcasting and how we get to Podcasting 2.0!&lt;/p&gt;</description>


### PR DESCRIPTION
Add support for liveItem parsing within the podcast extension (Resolves #39)

I took an existing PR and modified it: https://github.com/Flutter-Bounty-Hunters/dart-rss/pull/37

There were a couple bugs in that PR that I fixed. I also added example XML and a corresponding test update.

I discovered a couple missing parsing behaviors related to this work, but I filed #43 and #44.