### PR TITLE
Parse media thumbnails inside media group tag.

### DIFF
--- a/lib/domain/media/media.dart
+++ b/lib/domain/media/media.dart
@@ -33,7 +33,10 @@ class Media {
       title: Title.parse(findElementOrNull(element, 'media:title')),
       description: Description.parse(findElementOrNull(element, 'media:description')),
       keywords: findElementOrNull(element, 'media:keywords')?.innerText,
-      thumbnails: element.findElements('media:thumbnail').map((e) => Thumbnail.parse(e)).toList(),
+      thumbnails: element
+          .findAllElements('media:thumbnail')
+          .map((e) => Thumbnail.parse(e))
+          .toList(),
       hash: Hash.parse(findElementOrNull(element, 'media:hash')),
       player: Player.parse(findElementOrNull(element, 'media:player')),
       copyright: Copyright.parse(findElementOrNull(element, 'media:copyright')),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 dependencies:
   xml: ^6.3.0
   http: ^1.1.2
-  intl: ^0.19.0
+  intl: ^0.20.2
 
 dev_dependencies:
   test: ^1.16.4
-  lints: ^2.1.1
+  lints: ^6.0.0

--- a/test/atom_test.dart
+++ b/test/atom_test.dart
@@ -146,12 +146,22 @@ void main() {
 
     expect(item.media!.keywords, 'kitty, cat, big dog, yarn, fluffy');
 
-    expect(item.media!.thumbnails.length, 2);
-    final mediaThumbnail = item.media!.thumbnails.first;
-    expect(mediaThumbnail.url, 'http://www.foo.com/keyframe1.jpg');
-    expect(mediaThumbnail.width, '75');
-    expect(mediaThumbnail.height, '50');
-    expect(mediaThumbnail.time, '12:05:01.123');
+    expect(item.media!.thumbnails.length, 3);
+    final mediaThumbnail0 = item.media!.thumbnails.first;
+    expect(mediaThumbnail0.url, 'http://www.foo.com/keyframe0.jpg');
+    expect(mediaThumbnail0.width, '50');
+    expect(mediaThumbnail0.height, '25');
+    expect(mediaThumbnail0.time, null);
+    final mediaThumbnail1 = item.media!.thumbnails[1];
+    expect(mediaThumbnail1.url, 'http://www.foo.com/keyframe1.jpg');
+    expect(mediaThumbnail1.width, '75');
+    expect(mediaThumbnail1.height, '50');
+    expect(mediaThumbnail1.time, '12:05:01.123');
+    final mediaThumbnail2 = item.media!.thumbnails[2];
+    expect(mediaThumbnail2.url, 'http://www.foo.com/keyframe2.jpg');
+    expect(mediaThumbnail2.width, '150');
+    expect(mediaThumbnail2.height, '100');
+    expect(mediaThumbnail2.time, '12:05:01.125');
 
     expect(item.media!.hash!.algo, 'md5');
     expect(item.media!.hash!.value, 'dfdec888b72151965a34b4b59031290a');

--- a/test/xml/Atom-Media.xml
+++ b/test/xml/Atom-Media.xml
@@ -50,6 +50,7 @@
             <media:credit role="musician">band member 2</media:credit>
             <media:category>music/artist name/album/song</media:category>
             <media:rating>nonadult</media:rating>
+            <media:thumbnail url="http://www.foo.com/keyframe0.jpg" width="50" height="25" />   
         </media:group>
         <media:title type="plain">The Judy's -- The Moo Song</media:title>
         <media:description type="plain">This was some really bizarre band I listened to as a young lad.</media:description>


### PR DESCRIPTION
YouTube has a somewhat unique RSS feed style for thumbnails. It embeds thumbnails inside a media:group. (see https://www.youtube.com/feeds/videos.xml?channel_id=UCAL3JXZSzSm8AlZyD3nQdBA)

This change treats media:thumbnail inside media:group much like media:title and media:description inside media:group. All elements are searched for media:thumbnail, not just direct children of media.