### PR TITLE
[RSS 1][RSS 2] - Serialize (partial) feeds to XML

### DIFF
--- a/README_DEVELOPMENT.md
+++ b/README_DEVELOPMENT.md
@@ -1,0 +1,8 @@
+# Development
+
+## RSS Validation
+During development, it might be useful to validate an RSS document against the W3C specification.
+The following link will take you to a W3C validator service: 
+
+https://validator.w3.org/feed/check.cgi
+

--- a/lib/dart_rss.dart
+++ b/lib/dart_rss.dart
@@ -13,6 +13,9 @@ export 'domain/rss_image.dart';
 export 'domain/rss_item.dart';
 export 'domain/rss_source.dart';
 
+// RSS 1
+export 'domain/rss1_feed.dart';
+
 // Podcasts
 export 'domain/podcast_index/rss_podcast_index.dart';
 export 'domain/podcast_index/rss_podcast_index_alternate_enclosure.dart';

--- a/lib/domain/dart_rss.dart
+++ b/lib/domain/dart_rss.dart
@@ -3,6 +3,7 @@ import 'package:dart_rss/domain/rss1_feed.dart';
 import 'package:dart_rss/util/helpers.dart';
 import 'package:http/http.dart' as http;
 import 'package:xml/xml.dart' as xml;
+import 'package:xml/xml.dart';
 
 class WebFeed {
   static WebFeed fromXmlString(String xmlString) {
@@ -26,6 +27,7 @@ class WebFeed {
 
   static WebFeed fromRss1(Rss1Feed rss1feed) {
     return WebFeed(
+      rssVersion: RssVersion.rss1,
       title: rss1feed.title ?? rss1feed.dc?.title ?? '',
       description: rss1feed.description ?? rss1feed.dc?.description ?? '',
       links: [rss1feed.link],
@@ -44,6 +46,7 @@ class WebFeed {
 
   static WebFeed fromRss2(RssFeed rssFeed) {
     return WebFeed(
+      rssVersion: RssVersion.rss2,
       title: rssFeed.title ?? rssFeed.dc?.title ?? '',
       description: rssFeed.description ?? rssFeed.dc?.description ?? '',
       links: [rssFeed.link],
@@ -62,6 +65,7 @@ class WebFeed {
 
   static WebFeed fromAtom(AtomFeed atomFeed) {
     return WebFeed(
+      rssVersion: RssVersion.atom,
       title: atomFeed.title ?? '',
       description: atomFeed.subtitle ?? '',
       links: atomFeed.links.map((atomLink) => atomLink.href).toList(),
@@ -105,16 +109,55 @@ class WebFeed {
   }
 
   const WebFeed({
+    required this.rssVersion,
     required this.title,
     required this.description,
     required this.links,
     required this.items,
   });
 
+  final RssVersion rssVersion;
   final String title;
   final String description;
   final List<String?> links;
   final List<WebFeedItem> items;
+
+  XmlElement toXml() {
+    switch (rssVersion) {
+      case RssVersion.rss1:
+        return _toRss1Xml();
+      case RssVersion.rss2:
+        return _toRss2Xml();
+      case RssVersion.atom:
+        return _toAtomXml();
+      case RssVersion.unknown:
+        throw Exception("Can't serialize RSS to XML because the RSS version is unknown.");
+    }
+  }
+
+  XmlElement _toRss1Xml() {
+    final rss = xml.XmlElement(
+      xml.XmlName("channel"),
+    );
+
+    return rss;
+  }
+
+  XmlElement _toRss2Xml() {
+    final rss = xml.XmlElement(
+      xml.XmlName("channel"),
+    );
+
+    return rss;
+  }
+
+  XmlElement _toAtomXml() {
+    final rss = xml.XmlElement(
+      xml.XmlName("channel"),
+    );
+
+    return rss;
+  }
 }
 
 class WebFeedItem {

--- a/lib/domain/dart_rss.dart
+++ b/lib/domain/dart_rss.dart
@@ -1,5 +1,4 @@
 import 'package:dart_rss/dart_rss.dart';
-import 'package:dart_rss/domain/rss1_feed.dart';
 import 'package:dart_rss/util/helpers.dart';
 import 'package:http/http.dart' as http;
 import 'package:xml/xml.dart' as xml;

--- a/lib/domain/rss1_feed.dart
+++ b/lib/domain/rss1_feed.dart
@@ -96,7 +96,8 @@ class Rss1Feed {
           }
         });
 
-        image?.buildXml(builder);
+        // TODO: image serialization
+        // image?.buildXml(builder);
 
         for (final item in items) {
           item.buildXml(builder);

--- a/lib/domain/rss1_feed.dart
+++ b/lib/domain/rss1_feed.dart
@@ -73,6 +73,40 @@ class Rss1Feed {
   final int? updateFrequency;
   final DateTime? updateBase;
   final DublinCore? dc;
+
+  XmlDocument toXmlDocument() {
+    final builder = XmlBuilder();
+    builder
+      ..processing("xml", 'version="1.0"')
+      ..element("rdf:RDF", attributes: {
+        "xmlns:rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+        "xmlns": "http://purl.org/rss/1.0/",
+      }, nest: () {
+        builder.element("channel", nest: () {
+          if (title != null) {
+            builder.element("title", nest: title!);
+          }
+
+          if (description != null) {
+            builder.element("description", nest: description!);
+          }
+
+          if (link != null) {
+            builder.element("link", nest: link!);
+          }
+        });
+
+        image?.buildXml(builder);
+
+        for (final item in items) {
+          item.buildXml(builder);
+        }
+
+        // TODO: "textinput" element
+      });
+
+    return builder.buildDocument();
+  }
 }
 
 enum UpdatePeriod {

--- a/lib/domain/rss1_item.dart
+++ b/lib/domain/rss1_item.dart
@@ -28,4 +28,28 @@ class Rss1Item {
   final String? link;
   final DublinCore? dc;
   final RssContent? content;
+
+  void buildXml(XmlBuilder builder) {
+    builder.element("item", attributes: {
+      "rdf:about": "http://example/org/item/",
+    }, nest: () {
+      if (title != null) {
+        builder.element("title", nest: title);
+      }
+
+      if (description != null) {
+        builder.element("description", nest: description);
+      }
+
+      if (link != null) {
+        builder.element("link", nest: link);
+      }
+
+      if (content != null) {
+        content!.buildXml(builder);
+      }
+
+      // TODO: dc
+    });
+  }
 }

--- a/lib/domain/rss_content.dart
+++ b/lib/domain/rss_content.dart
@@ -25,6 +25,10 @@ class RssContent {
   final String value;
   final Iterable<String> images;
 
+  void buildXml(XmlBuilder builder) {
+    builder.element("content:encoded", nest: value);
+  }
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||

--- a/lib/domain/rss_feed.dart
+++ b/lib/domain/rss_feed.dart
@@ -87,8 +87,6 @@ class RssFeed {
   final String? author;
   final String? description;
   final String? link;
-  final List<RssItem> items;
-
   final RssImage? image;
   final RssCloud? cloud;
   final List<RssCategory> categories;
@@ -103,6 +101,9 @@ class RssFeed {
   final String? rating;
   final String? webMaster;
   final int ttl;
+
+  final List<RssItem> items;
+
   final DublinCore? dc;
   final RssItunes? itunes;
 

--- a/lib/domain/rss_image.dart
+++ b/lib/domain/rss_image.dart
@@ -14,7 +14,7 @@ class RssImage {
     return RssImage(title, url, link);
   }
 
-  const RssImage(this.title, this.link, this.url);
+  const RssImage(this.title, this.url, this.link);
 
   final String? title;
   final String? link;
@@ -31,7 +31,7 @@ class RssImage {
       }
 
       if (url != null) {
-        builder.element("link", nest: url!);
+        builder.element("url", nest: url!);
       }
     });
   }

--- a/lib/domain/rss_image.dart
+++ b/lib/domain/rss_image.dart
@@ -14,9 +14,25 @@ class RssImage {
     return RssImage(title, url, link);
   }
 
-  const RssImage(this.title, this.url, this.link);
+  const RssImage(this.title, this.link, this.url);
 
   final String? title;
-  final String? url;
   final String? link;
+  final String? url;
+
+  void buildXml(XmlBuilder builder) {
+    builder.element("image", nest: () {
+      if (title != null) {
+        builder.element("title", nest: title!);
+      }
+
+      if (link != null) {
+        builder.element("link", nest: link!);
+      }
+
+      if (url != null) {
+        builder.element("link", nest: url!);
+      }
+    });
+  }
 }

--- a/lib/domain/rss_item.dart
+++ b/lib/domain/rss_item.dart
@@ -65,4 +65,22 @@ class RssItem {
   final DublinCore? dc;
   final RssItemItunes? itunes;
   final RssItemPodcastIndex? podcastIndex;
+
+  void buildXml(XmlBuilder builder) {
+    builder.element("item", attributes: {
+      "rdf:about": "http://xml.com/pub/2000/08/09/xslt/xslt.html",
+    }, nest: () {
+      if (title != null) {
+        builder.element("title", nest: title!);
+      }
+
+      if (link != null) {
+        builder.element("link", nest: link!);
+      }
+
+      if (description != null) {
+        builder.element("description", nest: description!);
+      }
+    });
+  }
 }

--- a/lib/domain/rss_item.dart
+++ b/lib/domain/rss_item.dart
@@ -67,9 +67,7 @@ class RssItem {
   final RssItemPodcastIndex? podcastIndex;
 
   void buildXml(XmlBuilder builder) {
-    builder.element("item", attributes: {
-      "rdf:about": "http://xml.com/pub/2000/08/09/xslt/xslt.html",
-    }, nest: () {
+    builder.element("item", nest: () {
       if (title != null) {
         builder.element("title", nest: title!);
       }
@@ -80,6 +78,18 @@ class RssItem {
 
       if (description != null) {
         builder.element("description", nest: description!);
+      }
+
+      if (pubDate != null) {
+        builder.element("pubDate", nest: pubDate);
+      }
+
+      if (guid != null) {
+        builder.element("guid", nest: guid);
+      }
+
+      if (author != null) {
+        builder.element("author", nest: author);
       }
     });
   }

--- a/lib/domain/rss_item.dart
+++ b/lib/domain/rss_item.dart
@@ -66,6 +66,42 @@ class RssItem {
   final RssItemItunes? itunes;
   final RssItemPodcastIndex? podcastIndex;
 
+  RssItem copyWith({
+    String? title,
+    String? description,
+    String? link,
+    List<RssCategory>? categories,
+    String? guid,
+    String? pubDate,
+    String? author,
+    String? comments,
+    RssSource? source,
+    RssContent? content,
+    Media? media,
+    RssEnclosure? enclosure,
+    DublinCore? dc,
+    RssItemItunes? itunes,
+    RssItemPodcastIndex? podcastIndex,
+  }) {
+    return RssItem(
+      title: title ?? this.title,
+      description: description ?? this.description,
+      link: link ?? this.link,
+      categories: categories ?? this.categories,
+      guid: guid ?? this.guid,
+      pubDate: pubDate ?? this.pubDate,
+      author: author ?? this.author,
+      comments: comments ?? this.comments,
+      source: source ?? this.source,
+      content: content ?? this.content,
+      media: media ?? this.media,
+      enclosure: enclosure ?? this.enclosure,
+      dc: dc ?? this.dc,
+      itunes: itunes ?? this.itunes,
+      podcastIndex: podcastIndex ?? this.podcastIndex,
+    );
+  }
+
   void buildXml(XmlBuilder builder) {
     builder.element("item", nest: () {
       if (title != null) {

--- a/test/rss1_serialization_test.dart
+++ b/test/rss1_serialization_test.dart
@@ -1,0 +1,17 @@
+import 'dart:io';
+
+import 'package:dart_rss/dart_rss.dart';
+import 'package:test/scaffolding.dart';
+
+void main() {
+  group("RSS 1 >", () {
+    test("serialization >", () {
+      final feed = Rss1Feed.parse(
+        File('test/xml/RSS1-basic.xml').readAsStringSync(),
+      );
+
+      final xml = feed.toXmlDocument();
+      print(xml.toXmlString(pretty: true));
+    });
+  });
+}

--- a/test/rss1_serialization_test.dart
+++ b/test/rss1_serialization_test.dart
@@ -11,6 +11,7 @@ void main() {
       );
 
       final xml = feed.toXmlDocument();
+      // ignore: avoid_print
       print(xml.toXmlString(pretty: true));
     });
   });

--- a/test/rss_test.dart
+++ b/test/rss_test.dart
@@ -5,7 +5,6 @@ import 'package:dart_rss/dart_rss.dart';
 import 'package:dart_rss/domain/rss_itunes_episode_type.dart';
 import 'package:dart_rss/domain/rss_itunes_type.dart';
 import 'package:test/test.dart';
-import 'package:xml/xpath.dart';
 
 void main() {
   test('parse Invalid.xml', () {

--- a/test/rss_test.dart
+++ b/test/rss_test.dart
@@ -5,6 +5,7 @@ import 'package:dart_rss/dart_rss.dart';
 import 'package:dart_rss/domain/rss_itunes_episode_type.dart';
 import 'package:dart_rss/domain/rss_itunes_type.dart';
 import 'package:test/test.dart';
+import 'package:xml/xpath.dart';
 
 void main() {
   test('parse Invalid.xml', () {
@@ -420,6 +421,61 @@ void main() {
     expect(soundbite2.length, 1);
     expect(soundbite2[0]!.startTime, 45.4);
     expect(soundbite2[0]!.duration, 56.0);
+  });
+
+  group("serializes RSS 2 >", () {
+    test("smoke test", () {
+      const feed = RssFeed(
+        title: "Blog | Flutter Bounty Hunters",
+        description: "The Flutter Bounty Hunters blog.",
+        language: "en-us",
+        pubDate: "22 Nov 2022",
+        docs: "http://blogs.law.harvard.edu/tech/rss",
+        items: [
+          RssItem(
+            title: "We launched a new blog!",
+            link: "https://blog.flutterbountyhunters.com/we-launched-a-new-blog",
+            description: "The Flutter Bounty Hunters just launched a new blog. Check it out.",
+            pubDate: "22 Nov 2022",
+            guid: "/we-launched-a-new-blog",
+          ),
+          RssItem(
+            title: "10 Things the Flutter Team Should do in 2023",
+            link: "https://blog.flutterbountyhunters.com/ten-things-the-flutter-team-should-do-in-2023",
+            description: "Here's our selection of the top 10 things that we think the Flutter team should do in 2023.",
+            pubDate: "20 Dec 2022",
+            guid: "/ten-things-the-flutter-team-should-do-in-2023",
+          ),
+        ],
+      );
+
+      expect(
+        feed.toXmlDocument().toXmlString(pretty: true, indent: "  "),
+        '''<rss version="2.0">
+  <channel>
+    <title>Blog | Flutter Bounty Hunters</title>
+    <description>The Flutter Bounty Hunters blog.</description>
+    <language>en-us</language>
+    <pubDate>22 Nov 2022</pubDate>
+    <docs>http://blogs.law.harvard.edu/tech/rss</docs>
+    <item>
+      <title>We launched a new blog!</title>
+      <link>https://blog.flutterbountyhunters.com/we-launched-a-new-blog</link>
+      <description>The Flutter Bounty Hunters just launched a new blog. Check it out.</description>
+      <pubDate>22 Nov 2022</pubDate>
+      <guid>/we-launched-a-new-blog</guid>
+    </item>
+    <item>
+      <title>10 Things the Flutter Team Should do in 2023</title>
+      <link>https://blog.flutterbountyhunters.com/ten-things-the-flutter-team-should-do-in-2023</link>
+      <description>Here's our selection of the top 10 things that we think the Flutter team should do in 2023.</description>
+      <pubDate>20 Dec 2022</pubDate>
+      <guid>/ten-things-the-flutter-team-should-do-in-2023</guid>
+    </item>
+  </channel>
+</rss>''',
+      );
+    });
   });
 }
 

--- a/test/xml/RSS1-production_hatena.xml
+++ b/test/xml/RSS1-production_hatena.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://purl.org/rss/1.0/" xmlns:admin="http://webns.net/mvcb/" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:hatena="http://www.hatena.ne.jp/info/xmlns#" xmlns:syn="http://purl.org/rss/1.0/modules/syndication/" xmlns:taxo="http://purl.org/rss/1.0/modules/taxonomy/">
+<rdf:RDF
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns="http://purl.org/rss/1.0/"
+    xmlns:admin="http://webns.net/mvcb/"
+    xmlns:content="http://purl.org/rss/1.0/modules/content/"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:hatena="http://www.hatena.ne.jp/info/xmlns#"
+    xmlns:syn="http://purl.org/rss/1.0/modules/syndication/"
+    xmlns:taxo="http://purl.org/rss/1.0/modules/taxonomy/">
 
     <channel rdf:about="https://b.hatena.ne.jp/sample/bookmark">
         <title>sampleのはてなブックマーク</title>


### PR DESCRIPTION
Adds partial serialization of RSS 1 and RSS 2 to XML, so that it can be written to a file, like `feed.rss`.

This PR only adds partial serialization because these properties are needed for the Flutter Bounty Hunters blog right now. More properties can be added later. We should be able to add more property serializations without breaking the uses of the serialization in this PR.