### PR TITLE
Add Thumbnail to Media Group

### DIFF
--- a/lib/domain/media/group.dart
+++ b/lib/domain/media/group.dart
@@ -5,6 +5,8 @@ import 'package:dart_rss/domain/media/rating.dart';
 import 'package:dart_rss/util/helpers.dart';
 import 'package:xml/xml.dart';
 
+import 'thumbnail.dart';
+
 class Group {
   static Group? parse(XmlElement? element) {
     if (element == null) {
@@ -14,6 +16,7 @@ class Group {
     return Group(
       contents: element.findElements('media:content').map((e) => Content.parse(e)).toList(),
       credits: element.findElements('media:credit').map((e) => Credit.parse(e)).toList(),
+      thumbnails: element.findElements('media:thumbnail').map((e) => Thumbnail.parse(e)).toList(),
       category: Category.parse(findElementOrNull(element, 'media:category')),
       rating: Rating.parse(findElementOrNull(element, 'media:rating')),
     );
@@ -22,12 +25,14 @@ class Group {
   const Group({
     this.contents = const <Content>[],
     this.credits = const <Credit>[],
+    this.thumbnails = const <Thumbnail>[],
     this.category,
     this.rating,
   });
 
   final List<Content> contents;
   final List<Credit> credits;
+  final List<Thumbnail> thumbnails;
   final Category? category;
   final Rating? rating;
 }

--- a/test/atom_test.dart
+++ b/test/atom_test.dart
@@ -112,6 +112,12 @@ void main() {
     expect(item.media!.group!.category!.value, 'music/artist name/album/song');
     expect(item.media!.group!.rating!.value, 'nonadult');
 
+    final mediaGroupThumbnail = item.media!.group!.thumbnails.first;
+    expect(mediaGroupThumbnail.url, 'http://www.foo.com/keyframe1.jpg');
+    expect(mediaGroupThumbnail.width, '75');
+    expect(mediaGroupThumbnail.height, '50');
+    expect(mediaGroupThumbnail.time, '12:05:01.123');
+
     expect(item.media!.contents.length, 2);
     final mediaContent = item.media!.contents.first;
     expect(mediaContent.url, 'http://www.foo.com/video.mov');

--- a/test/xml/Atom-Media.xml
+++ b/test/xml/Atom-Media.xml
@@ -50,6 +50,7 @@
             <media:credit role="musician">band member 2</media:credit>
             <media:category>music/artist name/album/song</media:category>
             <media:rating>nonadult</media:rating>
+            <media:thumbnail url="http://www.foo.com/keyframe1.jpg" width="75" height="50" time="12:05:01.123" />
         </media:group>
         <media:title type="plain">The Judy's -- The Moo Song</media:title>
         <media:description type="plain">This was some really bizarre band I listened to as a young lad.</media:description>


### PR DESCRIPTION
For YouTube Atom Feeds, the thumbnails are under the Media Group.  This allows users to properly parse and interact with YouTube feeds while not affecting others.